### PR TITLE
article_summaries bugfix

### DIFF
--- a/lib/nesta/app.rb
+++ b/lib/nesta/app.rb
@@ -101,7 +101,7 @@ module Nesta
         haml(
           :summaries,
           :layout => false,
-          :locals => { :pages => latest_articles }
+          :locals => { :pages => articles }
         )
       end
     end


### PR DESCRIPTION
At the moment in app.rb, the article_summaries method takes one argument that is never used. It renders (through haml) the pages returned from a completely new call to latest_articles.

This fix simply uses the argument in the call to haml.

The example index.haml in the demo site calls article_summaries(latest_articles). Without this fix, changes to the arguments made to latest articles, eg:
    article_summaries(latest_articles 5)
do nothing as anything passed to article_summaries is ignored. Hell, you could:

```
article_summaries( :totally_ignored )
```

and the page would still render.

Now article_summaries(latest_articles 5) renders at most five articles.
