### PR TITLE
Fix timezone issue with Nesta::Page.find_articles

### DIFF
--- a/lib/nesta/models.rb
+++ b/lib/nesta/models.rb
@@ -149,7 +149,7 @@ module Nesta
 
     def self.find_articles
       find_all.select do |page|
-        page.date && page.date < DateTime.now
+        page.date && page.date < DateTime.now.to_date
       end.sort { |x, y| y.date <=> x.date }
     end
 

--- a/spec/models_spec.rb
+++ b/spec/models_spec.rb
@@ -185,8 +185,20 @@ describe "Page", :shared => true do
                                :metadata => { "date" => future_date })
       Nesta::Page.find_articles.detect{|a| a == article}.should be_nil
     end
+
+    it "should not find pages scheduled in the future outside GMT" do
+      future_date = '1 January 2011'
+      article = create_article(:heading => "Article 5",
+                               :path => "foo/article-5",
+                               :metadata => { "date" => future_date })
+      # Due to the timezone, this value is Jan 1 2011 in GMT
+      now = DateTime.parse('2010-12-31T20:00:01-04:00')
+      DateTime.stub!(:now).and_return(now)
+
+      Nesta::Page.find_articles.detect {|a| a == article}.should be_nil
+    end
   end
-  
+
   describe "when finding articles" do
     before(:each) do
       create_article(:heading => "Article 1", :path => "article-1")


### PR DESCRIPTION
The `Nesta::Page.find_articles` method returns articles written in the future when close to the day boundary and in a negative-GMT time zone. 
# Example

If your machine time zone is US-Eastern (GMT-04:00) the `find_articles` method returns the next day's articles anytime after 8:00PM, because `DateTime.now` returns a `DateTime` with a time zone, but `DateTime.parse` (which `Page#date` uses) returns a GMT-relative `DateTime`. This causes the `page.date < DateTime.now` to incorrectly return `true` anytime within the time zone offset.
# Fix

Since Nesta pages don't use times currently, this can be fixed by comparing `page.date` to `DateTime.now.to_date`, stripping off the time zone part of the value returned by `DateTime.now`. 

This pull request includes the fix as well as a new spec that fails without the fix applied.
