### PR TITLE
Fixed sass deprecation warning by adding the sass gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,9 @@ PATH
   specs:
     nesta (0.9.4)
       RedCloth (~> 4.2)
-      haml (~> 3.0)
+      haml (~> 3.1)
       maruku (>= 0.6.0)
+      sass (~> 3.1)
       shotgun (>= 0.8)
       sinatra (= 1.1.2)
 
@@ -12,7 +13,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     RedCloth (4.2.7)
-    haml (3.0.25)
+    haml (3.1.0)
     hoe (2.6.2)
       rake (>= 0.8.7)
       rubyforge (>= 2.0.4)
@@ -28,6 +29,7 @@ GEM
     rspec_hpricot_matchers (1.0)
     rubyforge (2.0.4)
       json_pure (>= 1.1.7)
+    sass (3.1.0)
     shotgun (0.9)
       rack (>= 1.0)
     sinatra (1.1.2)

--- a/nesta.gemspec
+++ b/nesta.gemspec
@@ -31,7 +31,8 @@ EOF
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('haml', '~> 3.0')
+  s.add_dependency('haml', '~> 3.1')
+  s.add_dependency('sass', '~> 3.1')
   s.add_dependency('maruku', '>= 0.6.0')
   s.add_dependency('RedCloth', '~> 4.2')
   s.add_dependency('sinatra', '1.1.2')


### PR DESCRIPTION
Updated haml to 3.1 and fixed sass deprecation warning by adding the sass gem as a dependency
