### PR TITLE
Fix a directory traversal allowing to retrieve any file within content

### DIFF
--- a/lib/nesta/app.rb
+++ b/lib/nesta/app.rb
@@ -128,9 +128,14 @@ module Nesta
       cache stylesheet(params[:sheet].to_sym)
     end
 
-    get %r{/attachments/([\w/.-]+)} do
-      file = File.join(Nesta::Config.attachment_path, params[:captures].first)
-      send_file(file, :disposition => nil)
+    get %r{/attachments/([\w/.-]+)} do |file|
+      raise Sinatra::NotFound if file =~ /\.\.\//
+      filename = File.join(Nesta::Config.attachment_path, file)
+      if File.exist?(filename) and File.file?(filename)
+        send_file(filename, :disposition => nil)
+      else 
+        raise Sinatra::NotFound 
+      end
     end
 
     get '/articles.xml' do

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -447,23 +447,33 @@ describe "attachments" do
   
   before(:each) do
     create_attachment
-    get "/attachments/test.txt"
   end
   
   after(:each) do
     remove_temp_directory
     Nesta::FileModel.purge_cache
   end
+
+
   
   it "should be served successfully" do
+    get "/attachments/test.txt"
     last_response.should be_ok
   end
   
   it "should be sent to the client" do
+    get "/attachments/test.txt"
     body.should include("I'm a test attachment")
   end
   
   it "should set the appropriate MIME type" do
+    get "/attachments/test.txt"
     last_response.headers["Content-Type"].should =~ Regexp.new("^text/plain")
   end
+  it "should be directory traversal free" do
+    get "/attachments/../pages/index.haml"
+    last_response.should_not be_ok
+  end
+ 
+
 end


### PR DESCRIPTION
I didn't use File.basename to allow people to use sub-directories in /content/attachments/blah/lol.png

the fix is quick and dirty but do the job based on Sinatra current protection regarding encoding and the use of the regular expression for the filename
