### PR TITLE
Add icon metadata field.

### DIFF
--- a/lib/nesta/models.rb
+++ b/lib/nesta/models.rb
@@ -113,7 +113,11 @@ module Nesta
     def keywords
       metadata('keywords')
     end
-    
+
+    def icon
+      metadata('icon')
+    end
+
     def metadata(key)
       @metadata[key]
     end


### PR DESCRIPTION
Hi, this is a trivial little patch to add an additional metadata field called "icon". I have found it useful to be able to use this to specify a path to an icon file, which can then be rendered.

E.g.

Icon: /attachments/article.png

Thanks!
