### PR TITLE
Support to erb by default in nesta! Tilt already supports it!

### DIFF
--- a/lib/nesta/models.rb
+++ b/lib/nesta/models.rb
@@ -8,7 +8,7 @@ Tilt.register Tilt::RedcarpetTemplate, 'mdown'
 
 module Nesta
   class FileModel
-    FORMATS = [:mdown, :haml, :textile]
+    FORMATS = [:erb, :mdown, :haml, :textile]
     @@cache = {}
 
     attr_reader :filename, :mtime


### PR DESCRIPTION
Just by adding the :erb format in the models.rb file allows nesta to support erb by default.
