### PR TITLE
Add ETags to text pages to save the visitor bandwidth

### DIFF
--- a/nesta.gemspec
+++ b/nesta.gemspec
@@ -36,6 +36,7 @@ EOF
   s.add_dependency('rdiscount', '~> 1.6')
   s.add_dependency('RedCloth', '~> 4.2')
   s.add_dependency('sinatra', '1.2.6')
+  s.add_dependency('rack', '~> 1.1')
   
   # Useful in development
   s.add_dependency('shotgun', '>= 0.8')

--- a/templates/config.ru
+++ b/templates/config.ru
@@ -3,6 +3,9 @@ require 'bundler/setup'
 
 Bundler.require(:default)
 
+use Rack::ConditionalGet
+use Rack::ETag
+
 require 'nesta/env'
 Nesta::Env.root = ::File.expand_path('.', ::File.dirname(__FILE__))
 


### PR DESCRIPTION
Implemented using Rack::ETags and Rack::ConditionalGet.

Note that ETags are not added if the underlying app (for example sinatra) sets Cache-Control to no-cache, sets an ETag or sets a Last-Modified header.

This is significant because files in attachments/ are served using sinatra's send_file which sets Last-Modified to the OS's mtime. Sinatra now uses Rack::File (since sinatra/sinatra@8d6a1b35bbee9ed01378df7efc5786240d9aa7a3) but Rack::File itself uses the same process (see [file.rb](https://github.com/rack/rack/blob/0fbb575c1983980f621319650280a4dc8ba2af6c/lib/rack/file.rb) line  71). Therefore static files do not get etags (we can set them manually if we want...).
