### PR TITLE
@heading = @title done twice

### DIFF
--- a/lib/nesta/app.rb
+++ b/lib/nesta/app.rb
@@ -165,7 +165,6 @@ module Nesta
 
     get '*' do
       set_common_variables
-      @heading = @title
       parts = params[:splat].map { |p| p.sub(/\/$/, '') }
       @page = Nesta::Page.find_by_path(File.join(parts))
       raise Sinatra::NotFound if @page.nil?


### PR DESCRIPTION
I would correct this myself but it's quicker to simply write this:

@heading = @title is called twice: once in set_common_variable (app.rb:50) and again, after that method gets called, in get '*' (app.rb:168).

Deleting the second one seems to be the way to go.
