### PR TITLE
Factor out body_markup as its own method in Page

### DIFF
--- a/lib/nesta/models.rb
+++ b/lib/nesta/models.rb
@@ -250,16 +250,19 @@ module Nesta
       end
     end
 
-    def body(scope = nil)
-      body_text = case @format
+    def body_markup
+      case @format
         when :mdown
           markup.sub(/^#[^#].*$\r?\n(\r?\n)?/, '')
         when :haml
           markup.sub(/^\s*%h1\s+.*$\r?\n(\r?\n)?/, '')
         when :textile
           markup.sub(/^\s*h1\.\s+.*$\r?\n(\r?\n)?/, '')
-        end
-      convert_to_html(@format, scope, body_text)
+      end
+    end
+
+    def body(scope = nil)
+      convert_to_html(@format, scope, body_markup)
     end
 
     def categories

--- a/spec/models_spec.rb
+++ b/spec/models_spec.rb
@@ -408,6 +408,10 @@ describe "Page", :shared => true do
     it "should not include metadata in the HTML" do
       @article.to_html.should_not have_tag("p", /^Date/)
     end
+
+    it "should not include heading in body markup" do
+      @article.body_markup.should_not include("My article"); 
+    end
     
     it "should not include heading in body" do
       @article.body.should_not have_tag("h1", "My article")


### PR DESCRIPTION
This is to support external code (plugin or user code) that wants to get the "body" markup of a page (i.e. the markup without the metadata or header.)
