### PR TITLE
In test code, go further into the future in the test to avoid time zone issues

### DIFF
--- a/spec/models_spec.rb
+++ b/spec/models_spec.rb
@@ -196,7 +196,8 @@ describe "Page", :shared => true do
     end
 
     it "should not find pages scheduled in the future" do
-      future_date = (Time.now + 86400).strftime("%d %B %Y")
+      # Go ahead by 2 days to avoid time zone issues (Midnight UTC "tomorrow" might be some hours into the past...)
+      future_date = (Time.now + 172800).strftime("%d %B %Y")
       article = create_article(:heading => "Article 4",
                                :path => "foo/article-4",
                                :metadata => { "date" => future_date })


### PR DESCRIPTION
If you're not in the UTC time zone, the "should not find pages scheduled in the future" specs fail if you run them at certain times of the day. This is because they create a page with a date without a time, and Ruby infers the time to be Midnight UTC.  But midnight UTC "tomorrow" (i.e. on the date following the local current day) can be in the past.  (For instance, if it's 8 PM on March 4th US Eastern, then Midnight UTC on March 5th was an hour ago.)

For a simple fix I've simply made it push 2 days into the future instead of 1--that should make the test's assumptions always true.

But this does raise a question about what the actual Nesta behavior should be on timeless dates.  I'll raise that as an issue separately...it's not obvious to me whether the current behavior should be changed.
