### PR TITLE
Don't rely on being chdir'd to the project root

### DIFF
--- a/lib/nesta/config.rb
+++ b/lib/nesta/config.rb
@@ -76,7 +76,9 @@ module Nesta
     private_class_method :from_yaml
     
     def self.get_path(dirname, basename)
-      basename.nil? ? dirname : File.join(dirname, basename)
+      # We want paths relative to the project root
+      abs_dirname = File.expand_path(dirname, Nesta::App.root)
+      basename.nil? ? abs_dirname : File.join(abs_dirname, basename)
     end
     private_class_method :get_path
   end

--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -169,7 +169,8 @@ describe "nesta" do
 
   describe "edit" do
     before(:each) do
-      Nesta::Config.stub!(:content_path).and_return('content')
+      Nesta::App.stub!(:root).and_return(@project_path)
+      stub_config_key('content','content')
       @page_path = 'path/to/page.mdown'
       @command = Nesta::Commands::Edit.new(@page_path)
       @command.stub!(:system)
@@ -177,7 +178,7 @@ describe "nesta" do
 
     it "should launch the editor" do
       ENV['EDITOR'] = 'vi'
-      full_path = File.join('content/pages', @page_path)
+      full_path = File.join(@project_path, 'content/pages', @page_path)
       @command.should_receive(:system).with(ENV['EDITOR'], full_path)
       @command.execute
     end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -64,4 +64,16 @@ describe "Config" do
       Nesta::Config.content.should == 'rack_env/path'
     end
   end
+
+  it "should prepend the project path to content path if the content path is relative" do
+    Nesta::App.stub!(:root).and_return("/project/path")
+    stub_config_key('content', 'relative/path')
+    Nesta::Config.content_path.should == "/project/path/relative/path"
+  end
+
+  it "should not prepend the project path to content path if the content path is absolute" do
+    Nesta::App.stub!(:root).and_return("/project/path")
+    stub_config_key('content', '/absolute/path')
+    Nesta::Config.content_path.should == "/absolute/path"
+  end
 end


### PR DESCRIPTION
While playing around with the changes made for #94 (which worked great) I noticed one quirk: Nesta relies on having the current directory be the project root.  I'm guessing that may break some embedding scenarios, and there really isn't a need for it--the fix here was rather simple, and won't break cases where you have an absolute content path configured.
