### PR TITLE
Override / define page heading using metadata

### DIFF
--- a/lib/nesta/models.rb
+++ b/lib/nesta/models.rb
@@ -206,16 +206,20 @@ module Nesta
     end
 
     def heading
-      regex = case @format
-        when :mdown
-          /^#\s*(.*?)(\s*#+|$)/
-        when :haml
-          /^\s*%h1\s+(.*)/
-        when :textile
-          /^\s*h1\.\s+(.*)/
-        end
-      markup =~ regex
-      Regexp.last_match(1)
+      if metadata('heading')
+        metadata('heading')
+      else
+        regex = case @format
+          when :mdown
+            /^#\s*(.*?)(\s*#+|$)/
+          when :haml
+            /^\s*%h1\s+(.*)/
+          when :textile
+            /^\s*h1\.\s+(.*)/
+          end
+        markup =~ regex
+        Regexp.last_match(1)
+      end
     end
   
     def title

--- a/spec/models_spec.rb
+++ b/spec/models_spec.rb
@@ -375,6 +375,7 @@ describe "Page", :shared => true do
       @read_more = 'Continue at your leisure'
       @skillz = 'ruby, guitar, bowstaff'
       @article = create_article(:metadata => {
+        'heading' => 'My interesting article',
         'date' => @date.gsub('September', 'Sep'),
         'description' => @description,
         'flags' => 'draft, orange',
@@ -404,7 +405,7 @@ describe "Page", :shared => true do
     end
     
     it "should retrieve heading" do
-      @article.heading.should == 'My article'
+      @article.heading.should == 'My interesting article'
     end
     
     it "should be possible to convert an article to HTML" do


### PR DESCRIPTION
Hi,

I had a few pages where I really didn't want to define a %h1 in order to set the menu heading, so I thought it would be a good idea to support this using just metadata.

Thanks :)

Ash.
