### PR TITLE
Fixed the generated gemspec file to use 'gem' object passed to the block (instead of 's', which doesn't exist)

### DIFF
--- a/lib/nesta/commands.rb
+++ b/lib/nesta/commands.rb
@@ -204,8 +204,8 @@ end
             output = ''
             file.each_line do |line|
               if line =~ /^end/
-                output << '  s.add_dependency("nesta", ">= 0.9.11")' + "\n"
-                output << '  s.add_development_dependency("rake")' + "\n"
+                output << '  gem.add_dependency("nesta", ">= 0.9.11")' + "\n"
+                output << '  gem.add_development_dependency("rake")' + "\n"
               end
               output << line
             end


### PR DESCRIPTION
In nesta's .gemspec, we use 's', but `bundle gem` generates a .gemspec file using a variable 'gem'.
