### PR TITLE
In the attachments route regex, the @ should preceed the -

### DIFF
--- a/lib/nesta/app.rb
+++ b/lib/nesta/app.rb
@@ -59,7 +59,7 @@ module Nesta
       cache stylesheet(params[:sheet].to_sym)
     end
 
-    get %r{/attachments/([\w/.-@]+)} do |file|
+    get %r{/attachments/([\w/.@-]+)} do |file|
       file = File.join(Nesta::Config.attachment_path, params[:captures].first)
       if file =~ /\.\.\//
         not_found


### PR DESCRIPTION
I made a mistake in my last pull request, "-"'s don't get matched unless it's the last character in the regex. 
