### PR TITLE
Add default_read_more configuration key

### DIFF
--- a/lib/nesta/config.rb
+++ b/lib/nesta/config.rb
@@ -4,6 +4,7 @@ module Nesta
   class Config
     @settings = %w[
       title subtitle theme disqus_short_name cache content google_analytics_code
+      read_more
     ]
     @author_settings = %w[name uri email]
     @yaml = nil
@@ -45,7 +46,11 @@ module Nesta
     def self.yaml_path
       File.expand_path('config/config.yml', Nesta::App.root)
     end
-    
+
+    def self.read_more
+      from_environment('read_more') || from_yaml('read_more') || 'Continue reading'
+    end
+
     def self.from_environment(setting)
       value = ENV["NESTA_#{setting.upcase}"]
       overrides = { "true" => true, "false" => false }

--- a/lib/nesta/models.rb
+++ b/lib/nesta/models.rb
@@ -248,7 +248,7 @@ module Nesta
     end
 
     def read_more
-      metadata('read more') || 'Continue reading'
+      metadata('read more') || Nesta::Config.read_more
     end
 
     def summary

--- a/templates/config/config.yml
+++ b/templates/config/config.yml
@@ -54,6 +54,14 @@ content: content
 #
 # google_analytics_code: "UA-???????-?"
 
+# read_more
+#     When the summary of an article is displayed
+#     on the home page, or on a category page, there is a link underneath the
+#     summary that points to the rest of the post. Use this value
+#     to customize the default link text. You can still override
+#     this value on a per-page basis with the 'Read more' metadata key.
+# read_more: "Continue reading"
+
 # Overriding "cache" and "content" in production is recommended if you're
 # deploying Nesta to your own server (but see the deployment documentation
 # on the Nesta site). Setting google_analytics_code in production is


### PR DESCRIPTION
This value allows the user to change the default 'Continue reading' string that is used when the `Read more` metadata is not set.
