### PR TITLE
Add breadcrumb options

### DIFF
--- a/lib/nesta/navigation.rb
+++ b/lib/nesta/navigation.rb
@@ -49,6 +49,11 @@ module Nesta
                   haml_concat link_text(page)
                 end
               end
+              if options[:divider]
+                haml_tag(:span, :<, :itemprop => 'divider', :class => options[:divider_class]) do
+                  haml_concat options[:divider]
+                end
+              end
             end
           end
           haml_tag(:li, :class => options[:active_class]) { haml_concat link_text(@page) }


### PR DESCRIPTION
This branch adds a couple of options to `display_breadcrumbs`. I added all these options so I could make Nesta's markup play well with [Bootstrap](http://twitter.github.com/bootstrap/components.html#breadcrumbs).
- **active_class** allows the user to add a class attribute to the final breadcrumb.
- **divider** allows the user to specify a text divider to be placed in between breadcrumbs.
- **divider_class** allows the user to specify a class attribute to slap on the breadcrumb divider.

Cheers.
