### PR TITLE
Pass all options down to submenus

### DIFF
--- a/lib/nesta/navigation.rb
+++ b/lib/nesta/navigation.rb
@@ -17,7 +17,8 @@ module Nesta
         if item.respond_to?(:each)
           if (options[:levels] - 1) > 0
             haml_tag :li do
-              display_menu(item, :levels => (options[:levels] - 1))
+              options[:levels] -= 1
+              display_menu(item, options)
             end
           end
         else


### PR DESCRIPTION
I'd like the `:class` option to be passed down to submenus as well, for use in Bootstrap. I'm not sure if this is always desirable behavior, or if this is the right way to go about the change.. If not, we could add another option (clunky) to control if the class options is passed down to submenus? Thoughts?
