### PR TITLE
move rdiscount and RedCloth into template Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,18 +2,14 @@ PATH
   remote: .
   specs:
     nesta (0.9.13)
-      RedCloth (~> 4.2)
       haml (~> 3.1)
       rack (~> 1.3)
-      rdiscount (~> 1.6)
       sass (~> 3.1)
-      shotgun (>= 0.8)
       sinatra (~> 1.3)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    RedCloth (4.2.9)
     ZenTest (4.6.2)
     addressable (2.2.7)
     diff-lcs (1.1.3)
@@ -31,19 +27,29 @@ GEM
       em-websocket (>= 0.2.0)
       guard (>= 0.10.0)
       multi_json (~> 1.0)
-    haml (3.1.4)
+    haml (3.1.8)
     hoe (2.15.0)
       rake (~> 0.8)
+    kgio (2.8.0)
+    listen (0.6.0)
+    mr-sparkle (0.0.2)
+      listen (~> 0.6.0)
+      rb-fsevent (~> 0.9.2)
+      rb-inotify (~> 0.8.8)
+      unicorn (~> 4.5.0)
     multi_json (1.1.0)
     nokogiri (1.5.5)
     rack (1.4.1)
-    rack-protection (1.2.0)
+    rack-protection (1.3.2)
       rack
     rack-test (0.6.1)
       rack (>= 1.0)
+    raindrops (0.10.0)
     rake (0.9.2.2)
+    rb-fsevent (0.9.3)
+    rb-inotify (0.8.8)
+      ffi (>= 0.5.0)
     rb-readline (0.4.2)
-    rdiscount (1.6.8)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)
       rspec-expectations (~> 2.12.0)
@@ -52,17 +58,19 @@ GEM
     rspec-expectations (2.12.0)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.12.0)
-    sass (3.1.15)
-    shotgun (0.9)
-      rack (>= 1.0)
-    sinatra (1.3.2)
-      rack (~> 1.3, >= 1.3.6)
-      rack-protection (~> 1.2)
+    sass (3.2.5)
+    sinatra (1.3.4)
+      rack (~> 1.4)
+      rack-protection (~> 1.3)
       tilt (~> 1.3, >= 1.3.3)
     test-unit (1.2.3)
       hoe (>= 1.5.1)
     thor (0.14.6)
     tilt (1.3.3)
+    unicorn (4.5.0)
+      kgio (~> 2.6)
+      rack
+      raindrops (~> 0.7)
     webrat (0.7.3)
       nokogiri (>= 1.2.0)
       rack (>= 1.0)
@@ -75,6 +83,7 @@ DEPENDENCIES
   ZenTest
   guard-ctags-bundler
   guard-livereload
+  mr-sparkle (>= 0.0.2)
   nesta!
   rack-test (= 0.6.1)
   rb-readline

--- a/nesta.gemspec
+++ b/nesta.gemspec
@@ -33,8 +33,6 @@ EOF
 
   s.add_dependency('haml', '~> 3.1')
   s.add_dependency('sass', '~> 3.1')
-  s.add_dependency('rdiscount', '~> 1.6')
-  s.add_dependency('RedCloth', '~> 4.2')
   s.add_dependency('sinatra', '~> 1.3')
   s.add_dependency('rack', '~> 1.3')
 

--- a/templates/Gemfile
+++ b/templates/Gemfile
@@ -4,6 +4,9 @@ gem 'nesta', '<%= Nesta::VERSION %>'
 <% if @options['vlad'] %>gem 'vlad', '2.1.0'
 gem 'vlad-git', '2.2.0'<% end %>
 
+gem 'rdiscount', '~> 1.6' # markdown
+gem 'RedCloth', '~> 4.2' # textile
+
 group :development do
   gem 'shotgun'
 end


### PR DESCRIPTION
It seems a bit wasteful to include these as dependencies when they aren't being used. (eg. using redcarpet)

I considered adding them as development dependencies, but all specs passed without doing so.

Fyi, there is a version 2 of rdiscount.
