### PR TITLE
Allow arbitrary config settings

### DIFF
--- a/lib/nesta/config.rb
+++ b/lib/nesta/config.rb
@@ -2,23 +2,15 @@ require 'yaml'
 
 module Nesta
   class Config
-    @settings = %w[
-      title subtitle theme disqus_short_name cache content google_analytics_code
-    ]
-    @author_settings = %w[name uri email]
     @yaml = nil
     
     class << self
-      attr_accessor :settings, :author_settings, :yaml_conf
+      attr_accessor :yaml_conf
     end
     
     def self.method_missing(method, *args)
       setting = method.to_s
-      if settings.include?(setting)
-        from_environment(setting) || from_yaml(setting)
-      else
-        super
-      end
+      from_environment(setting) || from_yaml(setting)
     end
     
     def self.author

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -63,5 +63,10 @@ describe "Config" do
       stub_config_key('content', 'rack_env/path', :rack_env => true)
       Nesta::Config.content.should == 'rack_env/path'
     end
+
+    it "should allow arbitrary config settings" do
+      stub_config_key('just_any_key', 'will work')
+      Nesta::Config.just_any_key.should == 'will work'
+    end
   end
 end


### PR DESCRIPTION
Fixes #127. Rather than checking requested settings against a list of
allowable keys, simply allow anything to be set in config.yml. Remove
commented out lines. 

(This is a squashed version of my previous pull request)
