### PR TITLE
allow for a way to override the root link name

### DIFF
--- a/lib/nesta/navigation.rb
+++ b/lib/nesta/navigation.rb
@@ -60,7 +60,7 @@ module Nesta
       def link_text(page)
         page.link_text
       rescue LinkTextNotSet
-        return 'Home' if page.abspath == '/'
+        return root_link_name if page.abspath == '/'
         raise
       end
 
@@ -79,6 +79,10 @@ module Nesta
 
       def current_breadcrumb_class
         nil
+      end
+
+      def root_link_name
+        'Home'
       end
     end
   end


### PR DESCRIPTION
this hook allows for a website to override the root link name if so desired.

one could override it using the code below:

``` ruby
# app.rb

module Nesta
  module Navigation
    module Renderers
      def root_link_name
        'My Website'
      end
    end
  end
end

```
