### PR TITLE
Fix issue generating a new plugin

### DIFF
--- a/lib/nesta/plugin.rb
+++ b/lib/nesta/plugin.rb
@@ -6,10 +6,12 @@ module Nesta
     self.loaded ||= []
 
     def self.register(path)
-      name = File.basename(path, '.rb')
+      # Maintain compatibility with plugins that pass filename
+      path = File.basename(path, '.rb') if path.end_with? '.rb'
       prefix = 'nesta-plugin-'
-      name.start_with?(prefix) || raise("Plugin names must match '#{prefix}*'")
-      self.loaded << name
+      plugin_name = path.tr('/', '-')
+      plugin_name.start_with?(prefix) || raise("Plugin names must match '#{prefix}*'")
+      self.loaded << path
     end
 
     def self.initialize_plugins

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -1,5 +1,36 @@
 require 'spec_helper'
 
+describe Nesta::Plugin do
+  describe "#register" do
+    before(:each) do
+      Nesta::Plugin.loaded.clear
+    end
+
+    context "with an absolute file path" do
+      it "should load plugin" do
+        Nesta::Plugin.register('/path/to/nesta-plugin-test.rb')
+        Nesta::Plugin.loaded.size.should == 1
+        Nesta::Plugin.loaded.last.should == 'nesta-plugin-test'
+      end
+    end
+
+    context "with a namespace path" do
+      it "should load plugin" do
+        namespace_path = 'nesta/plugin/test'
+        Nesta::Plugin.register(namespace_path)
+        Nesta::Plugin.loaded.size.should == 1
+        Nesta::Plugin.loaded.last.should == namespace_path
+      end
+    end
+
+    context "an invalid plugin name" do
+      it "should raise an error" do
+        expect { Nesta::Plugin.register('test') }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end
+
 describe "Plugin gem loading" do
   include ConfigSpecHelper
 


### PR DESCRIPTION
The nesta plugin:create command fails when attempting to generate the init.rb file due to a missing directory. I added a method call to create the needed directory as well refactored the tests a bit.