### PR TITLE
Selective env

### DIFF
--- a/lib/nesta/config.rb
+++ b/lib/nesta/config.rb
@@ -91,7 +91,7 @@ module Nesta
     private_class_method :yaml_exists?
 
     def self.can_use_yaml?
-      ENV.keys.grep(/^NESTA/).empty? && yaml_exists?
+      yaml_exists?
     end
     private_class_method :can_use_yaml?
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -18,10 +18,10 @@ describe "Config" do
       @title = "Title from ENV"
       ENV["NESTA_TITLE"] = @title
     end
-    
-    it "should never try and access config.yml" do
+
+    it "should fallback to config.yml" do
       stub_config_key("subtitle", "Subtitle in YAML file")
-      Nesta::Config.subtitle.should be_nil
+      Nesta::Config.subtitle.should == "Subtitle in YAML file"
     end
 
     it "should override config.yml" do


### PR DESCRIPTION
This pull request allows YAML and environment variable configs to co-exist with each other. This also means a user can specify an environment variable of `NESTA*` without causing nesta to completely change where it reads it's config from.

I also had to change the way fallback to YAML happens as falsy values defined in ENV would be ignored.