### PR TITLE
Rakefile for plugins to handle gem releases & management

### DIFF
--- a/lib/nesta/commands/command.rb
+++ b/lib/nesta/commands/command.rb
@@ -27,7 +27,7 @@ module Nesta
 
       def copy_template(src, dest)
         FileUtils.mkdir_p(File.dirname(dest))
-        template = ERB.new(File.read(File.join(template_root, src)))
+        template = ERB.new(File.read(File.join(template_root, src)), nil, "-")
         File.open(dest, 'w') { |file| file.puts template.result(binding) }
       end
 

--- a/lib/nesta/commands/plugin/create.rb
+++ b/lib/nesta/commands/plugin/create.rb
@@ -20,60 +20,78 @@ module Nesta
           File.join(@gem_name, 'lib', *parts)
         end
 
-        def modify_required_file
-          File.open(lib_path("#{@gem_name}.rb"), 'w') do |file|
-            file.write <<-EOF
-require "#{@gem_name}/version"
+        # def modify_required_file
+          # File.open(lib_path("#{@gem_name}.rb"), 'w') do |file|
+            # file.write <<-EOF
+# require "#{@gem_name}/version"
 
-Nesta::Plugin.register(__FILE__)
-            EOF
-          end
+# Nesta::Plugin.register(__FILE__)
+            # EOF
+          # end
+        # end
+
+        # def modify_init_file
+          # module_name = @name.split('-').map { |name| name.capitalize }.join('::')
+          # File.open(lib_path(@gem_name, 'init.rb'), 'w') do |file|
+            # file.puts <<-EOF
+# module Nesta
+  # module Plugin
+    # module #{module_name}
+      # module Helpers
+        # # If your plugin needs any helper methods, add them here...
+      # end
+    # end
+  # end
+
+  # class App
+    # helpers Nesta::Plugin::#{module_name}::Helpers
+  # end
+# end
+            # EOF
+          # end
+        # end
+
+        # def specify_gem_dependency
+          # gemspec = File.join(@gem_name, "#{@gem_name}.gemspec")
+          # File.open(gemspec, 'r+') do |file|
+            # output = ''
+            # file.each_line do |line|
+              # if line =~ /^end/
+                # output << '  gem.add_dependency("nesta", ">= 0.9.11")' + "\n"
+                # output << '  gem.add_development_dependency("rake")' + "\n"
+              # end
+              # output << line
+            # end
+            # file.pos = 0
+            # file.print(output)
+            # file.truncate(file.pos)
+          # end
+        # end
+
+        def module_name
+          @name.split('-').map { |name| name.capitalize }.join('::')
         end
 
-        def modify_init_file
-          module_name = @name.split('-').map { |name| name.capitalize }.join('::')
-          File.open(lib_path(@gem_name, 'init.rb'), 'w') do |file|
-            file.puts <<-EOF
-module Nesta
-  module Plugin
-    module #{module_name}
-      module Helpers
-        # If your plugin needs any helper methods, add them here...
-      end
-    end
-  end
-
-  class App
-    helpers Nesta::Plugin::#{module_name}::Helpers
-  end
-end
-            EOF
-          end
+        def make_directories
+          FileUtils.mkdir_p(File.join(@gem_name, 'lib', @gem_name))
         end
 
-        def specify_gem_dependency
-          gemspec = File.join(@gem_name, "#{@gem_name}.gemspec")
-          File.open(gemspec, 'r+') do |file|
-            output = ''
-            file.each_line do |line|
-              if line =~ /^end/
-                output << '  gem.add_dependency("nesta", ">= 0.9.11")' + "\n"
-                output << '  gem.add_development_dependency("rake")' + "\n"
-              end
-              output << line
-            end
-            file.pos = 0
-            file.print(output)
-            file.truncate(file.pos)
-          end
+        def gem_path(path)
+          File.join(@gem_name, path)
         end
 
         def execute
-          run_process('bundle', 'gem', @gem_name)
-          modify_required_file
-          modify_init_file
-          specify_gem_dependency
-          Dir.chdir(@gem_name) { run_process('git', 'add', '.') }
+          make_directories
+          copy_templates(
+            'plugins/gitignore' => gem_path('.gitignore'),
+            'plugins/plugin.gemspec' => gem_path("#{@gem_name}.gemspec"),
+            'plugins/Gemfile' => gem_path('Gemfile'),
+            'plugins/lib/required.rb' => gem_path("lib/#{@gem_name}.rb")
+          )
+          # modify_required_file
+          # modify_init_file
+          # specify_gem_dependency
+          # Dir.chdir(@gem_name) { run_process('git', 'add', '.') }
         end
       end
     end

--- a/lib/nesta/commands/plugin/create.rb
+++ b/lib/nesta/commands/plugin/create.rb
@@ -86,7 +86,9 @@ module Nesta
             'plugins/gitignore' => gem_path('.gitignore'),
             'plugins/plugin.gemspec' => gem_path("#{@gem_name}.gemspec"),
             'plugins/Gemfile' => gem_path('Gemfile'),
-            'plugins/lib/required.rb' => gem_path("lib/#{@gem_name}.rb")
+            'plugins/lib/required.rb' => gem_path("lib/#{@gem_name}.rb"),
+            'plugins/lib/version.rb' => gem_path("lib/#{@gem_name}/version.rb"),
+            'plugins/Rakefile' => gem_path('Rakefile')
           )
           # modify_required_file
           # modify_init_file

--- a/spec/commands/plugin/create_spec.rb
+++ b/spec/commands/plugin/create_spec.rb
@@ -51,7 +51,9 @@ describe "nesta:plugin:create" do
     should_exist('Gemfile')
   end
 
-  it "creates Rakefile that helps with packaging the gem"
+  it "creates Rakefile that helps with packaging the gem" do
+    should_exist("Rakefile")
+  end
 
   it "creates default folder for Ruby files" do
     code_directory = File.join(@gem_name, 'lib', @gem_name)

--- a/spec/commands/plugin/create_spec.rb
+++ b/spec/commands/plugin/create_spec.rb
@@ -4,6 +4,19 @@ require File.expand_path('../../../lib/nesta/commands', File.dirname(__FILE__))
 describe "nesta:plugin:create" do
   include_context "temporary working directory"
 
+  def path_in_gem(path)
+    File.join(@gem_name, path)
+  end
+
+  def should_exist(path)
+    File.exist?(path_in_gem(path)).should be_true
+  end
+  
+  def should_contain(path, pattern)
+    contents = File.read(path_in_gem(path))
+    contents.should match(pattern)
+  end
+
   before(:each) do
     @name = 'my-feature'
     @gem_name = "nesta-plugin-#{@name}"
@@ -11,8 +24,7 @@ describe "nesta:plugin:create" do
     @working_dir = Dir.pwd
     Dir.mkdir(@plugins_path)
     Dir.chdir(@plugins_path)
-    @command = Nesta::Commands::Plugin::Create.new(@name)
-    @command.stub(:run_process)
+    Nesta::Commands::Plugin::Create.new(@name).execute
   end
 
   after(:each) do
@@ -20,59 +32,35 @@ describe "nesta:plugin:create" do
     FileUtils.rm_r(@plugins_path)
   end
 
-  it "should create a new gem prefixed with nesta-plugin" do
-    @command.should_receive(:run_process).with('bundle', 'gem', @gem_name)
-    begin
-      @command.execute
-    rescue Errno::ENOENT
-      # This test is only concerned with running bundle gem; ENOENT
-      # errors are raised because we didn't create a real gem.
-    end
+  it "creates the gem's directory" do
+    File.directory?(@gem_name).should be_true
   end
 
-  describe "after gem created" do
-    def create_gem_file(*components)
-      path = File.join(@plugins_path, @gem_name, *components)
-      FileUtils.makedirs(File.dirname(path))
-      File.open(path, 'w') { |f| yield f if block_given? }
-      path
-    end
+  it "creates .gitignore" do
+    should_exist('.gitignore')
+  end
 
-    before(:each) do
-      @required_file = create_gem_file('lib', "#{@gem_name}.rb")
-      @init_file = create_gem_file('lib', @gem_name, 'init.rb')
-      @gem_spec = create_gem_file("#{@gem_name}.gemspec") do |file|
-        file.puts "  # specify any dependencies here; for example:"
-        file.puts "end"
-      end
-    end
+  it "creates the gemspec" do
+    path = "#{@gem_name}.gemspec"
+    should_exist(path)
+    should_contain(path, %r{require "#{@gem_name}/version"})
+    should_contain(path, %r{Nesta::Plugin::My::Feature::VERSION})
+  end
 
-    after(:each) do
-      FileUtils.rm(@required_file)
-      FileUtils.rm(@init_file)
-    end
+  it "creates a Gemfile" do
+    should_exist('Gemfile')
+  end
 
-    it "should create the ruby file loaded on require" do
-      @command.execute
-      File.read(@required_file).should include('Plugin.register(__FILE__)')
-    end
+  it "creates Rakefile that helps with packaging the gem"
 
-    it "should create a default init.rb file" do
-      @command.execute
-      init = File.read(@init_file)
-      boilerplate = <<-EOF
-    module My::Feature
-      module Helpers
-      EOF
-      init.should include(boilerplate)
-      init.should include('helpers Nesta::Plugin::My::Feature::Helpers')
-    end
+  it "creates default folder for Ruby files" do
+    code_directory = File.join(@gem_name, 'lib', @gem_name)
+    File.directory?(code_directory).should be_true
+  end
 
-    it "should specify plugin gem's dependencies" do
-      @command.execute
-      text = File.read(@gem_spec)
-      text.should include('gem.add_dependency("nesta", ">= 0.9.11")')
-      text.should include('gem.add_development_dependency("rake")')
-    end
+  it "creates file required when gem loaded" do
+    path = "#{File.join('lib', @gem_name)}.rb"
+    should_exist(path)
+    should_contain(path, %r{require "#{@gem_name}/version"})
   end
 end

--- a/templates/plugins/Gemfile
+++ b/templates/plugins/Gemfile
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+# Specify your gem's dependencies in <%= @gem_name %>.gemspec
+gemspec

--- a/templates/plugins/Rakefile
+++ b/templates/plugins/Rakefile
@@ -1,0 +1,56 @@
+def version
+  contents = File.read(File.join(File.dirname(__FILE__), "lib", name, "version.rb"))
+  contents.match(/VERSION = "([0-9a-z\.]+)".*$/)
+  $1
+end
+
+def name
+  "<%= @gem_name %>"
+end
+
+def built_gem_path
+  Dir[File.join(File.dirname(__FILE__), "pkg", "#{name}-*.gem")].sort_by{|f| File.mtime(f)}.last
+end
+
+def already_tagged?
+  `git tag`.split(/\n/).include?("v#{version}")
+end
+
+desc "Build #{name}-#{version}.gem into the pkg directory."
+task 'build' do
+  `gem build -V #{File.join(File.dirname(__FILE__), "#{name}.gemspec")}`
+  FileUtils.mkdir_p(File.join(File.dirname(__FILE__), "pkg"))
+  gem = Dir[File.join(File.dirname(__FILE__), "#{name}-*.gem")].sort_by{|f| File.mtime(f)}.last
+  FileUtils.mv(gem, 'pkg')
+  puts "#{name} #{version} built to #{built_gem_path}."
+end
+
+desc "Build and install #{name}-#{version}.gem into system gems."
+task 'install' => 'build' do
+  `gem install '#{built_gem_path}' --local`
+end
+
+desc "Create tag v#{version} and build and push #{name}-#{version}.gem to Rubygems\n" \
+     "To prevent publishing in Rubygems use `gem_push=no rake release`"
+task 'release' => ['build', 'release:guard_clean',
+                   'release:source_control_push', 'release:rubygem_push'] do
+end
+
+task 'release:guard_clean' do
+  if !system("git diff --exit-code") || !system("git diff-index --quiet --cached HEAD")
+    puts "There are files that need to be committed first."
+    exit(1)
+  end
+end
+
+task 'release:source_control_push' do
+  unless already_tagged?
+    `git tag -a -m "Version #{version}" v#{version}`
+    `git push`
+    `git push --tags`
+  end
+end
+
+task 'release:rubygem_push' do
+  `gem push e#{built_gem_path}`
+end

--- a/templates/plugins/gitignore
+++ b/templates/plugins/gitignore
@@ -1,0 +1,4 @@
+*.gem
+.bundle
+Gemfile.lock
+pkg/*

--- a/templates/plugins/lib/required.rb
+++ b/templates/plugins/lib/required.rb
@@ -1,0 +1,3 @@
+require "<%= @gem_name %>/version"
+
+Nesta::Plugin.register(__FILE__)

--- a/templates/plugins/plugin.gemspec
+++ b/templates/plugins/plugin.gemspec
@@ -1,0 +1,28 @@
+# -*- encoding: utf-8 -*-
+lib = File.expand_path('../lib', __FILE__)                                       
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)  
+require "<%= @gem_name %>/version"
+
+Gem::Specification.new do |spec|
+  spec.name        = "<%= @gem_name %>"
+  spec.version     = Nesta::Plugin::<%= module_name %>::VERSION
+  spec.authors     = ["TODO: Your name"]
+  spec.email       = ["TODO: Your email address"]
+  spec.homepage    = ""
+  spec.summary     = %q{TODO: Write a gem summary}
+  spec.description = %q{TODO: Write a gem description}
+  spec.license     = "MIT"
+
+  spec.rubyforge_project = "<%= @gem_name %>"
+
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }       
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/}) 
+  spec.require_paths = ["lib"]
+
+  # specify any dependencies here; for example:
+  # spec.add_development_dependency "rspec"
+  # spec.add_runtime_dependency "rest-client"
+  spec.add_dependency("nesta", ">= 0.9.11")
+  spec.add_development_dependency("rake")
+end


### PR DESCRIPTION
Opening this PR to start a discussion on direction and implementation, I don't think this is ready to merge yet.

As we've discussed out of band, this missing piece to stop us being tied to a specific version of Bundler is to reproduce the `Rakefile` it generates for managing gem releases. It wasn't as straightforward as I'd expected given the `Rakefile` itself calls into Bundler methods, and so those needed to be reproduced locally. I initially copied both the specs and implementation wholesale but ran into some problems because the specs actually call out to `git` and `gem` when they run. Here's a rough collection of notes I made about potentially significant changes to the specs:

- removed specs around installing. It's mostly re-testing building + ability to shell out to the gem command. I’m going to assume we can rely on “gem install” working, and avoid permanently changing the state of my machine because I ran a spec.
- stubbed out all calls that executed an external command (e.g., `git` and `gem`)
- currently no tests around building a gem. Thinking they’re of dubious value given all the implementation does is shell out to `gem build`, capture and pass on any error output, and then move the `.gem` file into `pkg/` when successful. The last bit seems like the only useful bit to test, the rest should be taking as a contract with the `gem`. Thoughts?
- removed references to the gemspec object. We’ve no reason to interrogate a gem spec

They're now passing. That said there is probably some room for improving the implementation, at the very least I'm not comfortable with the namespace I've dropped everything into. I'll need to take a break and come back to this with fresh eyes to have some objectivity on what to fix. 

Let me know if you've any suggestions, or if we should just kill it :fire: 