### PR TITLE
gemspec: Drop deprecated and unused property

### DIFF
--- a/nesta.gemspec
+++ b/nesta.gemspec
@@ -24,8 +24,6 @@ Implementing your site's design is easy, but Nesta also has a small
 selection of themes to choose from.
 EOF
 
-  s.rubyforge_project = "nesta"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.

[Source code location with the deprecation](https://github.com/rubygems/rubygems/blob/a7e2f87e94791206d2e7bb12ff7ce75442811ce8/lib/rubygems/specification.rb#L735)