### PR TITLE
Use sass-embedded support from sinatra 3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ PATH
       rake
       rdiscount (~> 2.1)
       sass-embedded (~> 1.58)
-      sinatra (~> 3.0)
-      tilt (~> 2.0)
+      sinatra (~> 3.1)
+      tilt (~> 2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -61,8 +61,8 @@ GEM
     public_suffix (5.0.1)
     racc (1.6.2)
     rack (2.2.6.4)
-    rack-protection (3.0.5)
-      rack
+    rack-protection (3.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-test (2.0.2)
       rack (>= 1.3)
     raindrops (0.20.1)
@@ -78,10 +78,10 @@ GEM
     sass-embedded (1.58.3)
       google-protobuf (~> 3.21)
       rake (>= 10.0.0)
-    sinatra (3.0.5)
+    sinatra (3.1.0)
       mustermann (~> 3.0)
       rack (~> 2.2, >= 2.2.4)
-      rack-protection (= 3.0.5)
+      rack-protection (= 3.1.0)
       tilt (~> 2.0)
     temple (0.10.0)
     tilt (2.1.0)

--- a/lib/nesta/overrides.rb
+++ b/lib/nesta/overrides.rb
@@ -12,23 +12,9 @@ module Nesta
         end
       end
 
-      def scss(template, options = {}, locals = {})
-        find_template(Nesta::App.settings.views, template, Tilt::ScssTemplate) do |file|
-          return Tilt.new(file).render if File.exist?(file)
-        end
-        raise IOError, "SCSS template not found: #{template}"
-      end
-
-      def sass(template, options = {}, locals = {})
-        find_template(Nesta::App.settings.views, template, Tilt::SassTemplate) do |file|
-          return Tilt.new(file).render if File.exist?(file)
-        end
-        raise IOError, "Sass template not found: #{template}"
-      end
-
       def stylesheet(template, options = {}, locals = {})
         scss(template, options, locals)
-      rescue IOError
+      rescue Errno::ENOENT
         sass(template, options, locals)
       end
     end

--- a/nesta.gemspec
+++ b/nesta.gemspec
@@ -36,8 +36,8 @@ EOF
   s.add_dependency('rdiscount', '~> 2.1')
   s.add_dependency('RedCloth', '~> 4.2')
   s.add_dependency('sass-embedded', '~> 1.58')
-  s.add_dependency('sinatra', '~> 3.0')
-  s.add_dependency('tilt', '~> 2.0')
+  s.add_dependency('sinatra', '~> 3.1')
+  s.add_dependency('tilt', '~> 2.1')
 
   # Useful in development
   s.add_development_dependency('mr-sparkle')


### PR DESCRIPTION
This PR remove the overrides for supporting sass, and use built-in support from sinatra 3.1.