### PR TITLE
Fix env specific var bug

### DIFF
--- a/lib/nesta/config.rb
+++ b/lib/nesta/config.rb
@@ -33,10 +33,11 @@ module Nesta
       setting = setting.to_s
       self.config ||= read_config_file(setting)
       env_config = config.fetch(Nesta::App.environment.to_s, {})
-      env_config.fetch(
-        setting,
-        config.fetch(setting) { raise NotDefined.new(setting) }
-      )
+      env_config.fetch(setting) do
+        config.fetch(setting) do
+          raise NotDefined.new(setting)
+        end
+      end
     rescue NotDefined
       default.empty? && raise || (return default.first)
     end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -38,6 +38,12 @@ describe Nesta::Config do
     end
   end
 
+  it 'returns environment specific settings' do
+    stub_config('test' => { 'content' => 'rack_env_specific/path'}) do
+      assert_equal 'rack_env_specific/path', Nesta::Config.content
+    end
+  end
+
   it 'overrides top level settings with environment specific settings' do
     config = {
       'content' => 'general/path',


### PR DESCRIPTION
Fixes a bug which caused env specific vars to always return nil if the same var wasn't also defined at the top level.